### PR TITLE
Fix style

### DIFF
--- a/assets/js/lib.js
+++ b/assets/js/lib.js
@@ -1,30 +1,30 @@
 const Library = {
 
    getJSON(path) {
-      return fetch(path).then(response => response.json())
+      return fetch(path).then(response => response.json());
    },
 
    print(msg) {
-     const text = document.createElement("h5")
-     text.innerText = msg
-     output.appendChild(text)
+     const text = document.createElement('h5');
+     text.innerText = msg;
+     output.appendChild(text);
    },
 
    printLight(msg, top) {
-     const text = document.createElement("p")
-     text.className = "lead"
-     text.innerText = msg
+     const text = document.createElement('p');
+     text.className = 'lead';
+     text.innerText = msg;
 
      /* is prepend standard? */
      if (top) {
-       output.prepend(text)
+       output.prepend(text);
      } else {
-       output.appendChild(text)
+       output.appendChild(text);
      }
    },
 
    clearOutput() {
-     document.getElementById("output").innerHTML = ""
+     document.getElementById('output').innerHTML = '';
    }
 
 }

--- a/content/async/index.md
+++ b/content/async/index.md
@@ -54,13 +54,13 @@ Once the server responds a event is put onto the event queue and when it is its 
 // this get's called at a later time whenever
 // the server responds
 
-function callback(data){
+function callback(data) {
   // use the data
 }
 
 
-let oReq = new XMLHttpRequest()
-oReq.addEventListener("load", callback)
+let oReq = new XMLHttpRequest();
+oReq.addEventListener("load", callback);
 
 // these lines return super quickly even though
 // the server hasn't responded. They don't wait.
@@ -93,7 +93,7 @@ When you are writing code it's natural to think out your logic top down like thi
 
 ```js
 let name = get_name();
-document.getElementById("name").value = name
+document.getElementById("name").value = name;
 ```
 but if get_name makes a network call you can't do that, you'd have to do..
 
@@ -111,26 +111,26 @@ get_name(callback);
 
 ```js
 function callback(name) {
-  document.getElementById("name").value = name
+  document.getElementById("name").value = name;
 }
-document.getElementById("name").value = "lol"
+document.getElementById("name").value = "lol";
 
-get_name(callback)
+get_name(callback);
 // will print out 'lol' because the callback hasn't  
 // been called yet and we don't know when it will
 // be called.
-console.log(document.getElementById("name").value)
+console.log(document.getElementById("name").value);
 ```
 
 So if you want to do several things that are async in order you have to nest callback functions
 
 ```js
-do_step_1(()=>{
-  step_1_logic()
-  do_step_2(()=>{
-    step_2_logic()
-    do_step_3(()=>{
-      step_3_logic()
+do_step_1(() => {
+  step_1_logic();
+  do_step_2(() => {
+    step_2_logic();
+    do_step_3(() => {
+      step_3_logic();
     })
   })
 })
@@ -156,14 +156,14 @@ Consider the following:
 
 ```js
 function successCallback(result) {
-  console.log("Audio file ready at URL: " + result)
+  console.log("Audio file ready at URL: " + result);
 }
 
 function failureCallback(error) {
-  console.log("Error generating audio file: " + error)
+  console.log("Error generating audio file: " + error);
 }
 
-createAudioFileAsync(audioSettings, successCallback, failureCallback)
+createAudioFileAsync(audioSettings, successCallback, failureCallback);
 ```
 
 This is how we used to do things, if you wanted to create an async function you'd define your own interface and take in callback functions.
@@ -173,7 +173,7 @@ But if instead `createAudioFileAsync` returned a `Promise` object you could do t
 ```js
 createAudioFileAsync(audioSettings)
    .then(successCallback)
-   .catch(failureCallback)
+   .catch(failureCallback);
 ```
 
 The `Promise` object will be notified when the audio file is done and it can then refer to the success and failure functions the user specified.
@@ -195,7 +195,7 @@ doSomething()
       return value of the previous promise
    */
    .then(newResult => doThirdThing(newResult))
-   .then(finalResult => console.log('Got the final result!'))
+   .then(finalResult => console.log('Got the final result!'));
 
 ```
 
@@ -207,20 +207,20 @@ We can use this
 
 ```js
 doSomething()
-.then(result => doSomethingElse(result))
-.then(newResult => return doThirdThing(newResult))
-.then(finalResult => console.log('Got the final result!'))
-.then(null,failureCallback)
+  .then(result => doSomethingElse(result))
+  .then(newResult => return doThirdThing(newResult))
+  .then(finalResult => console.log('Got the final result!'))
+  .then(null,failureCallback);
 ```
 
 Or we can use the shorthand:
 
 ```js
 doSomething()
-.then(result => doSomethingElse(result))
-.then(newResult => return doThirdThing(newResult))
-.then(finalResult => console.log('Got the final result!'))
-.catch(failureCallback)
+  .then(result => doSomethingElse(result))
+  .then(newResult => return doThirdThing(newResult))
+  .then(finalResult => console.log('Got the final result!'))
+  .catch(failureCallback);
 ```
 
 ..to catch a failure on the whole chain rather then defining a failure for reach individual step.
@@ -230,15 +230,16 @@ Note that how this works is that if one step fails it notifies the next promise 
 Of course it's possible to chain after a failure if you wish to do some cleanup regardless if a failure occurred or not.
 
 ```js
-// simulate failure
-myPromise.then(() => throw new Error('Something failed'))
-// handle failure
-.catch(() => console.log('Do that'))
-// do cleanup
-.then(() => console.log('Do this, no matter what happened before'))
-// this could also be written as finally
-// ie
-.finally(() => console.log("Always do this."))
+myPromise
+  // simulate failure
+  .then(() => throw new Error('Something failed'))
+  // handle failure
+  .catch(() => console.log('Do that'))
+  // do cleanup
+  .then(() => console.log('Do this, no matter what happened before'))
+  // this could also be written as finally
+  // ie
+  .finally(() => console.log("Always do this."))
 ```
 
 #### Creating Promises
@@ -265,8 +266,10 @@ eg.
 
 ```js
 const data = 10
-Promise.resolve(data)
-.then(data => doSomethingElse(data))
+Promise
+  .resolve(data)
+  .then(data => doSomethingElse(data))
+  //TODO: should we do `.then(doSomethingElse)` instead?
 ```
 
 #### Uses Of Promises
@@ -277,7 +280,7 @@ So one of the things JavaScript introduced recently is the `fetch` function whic
 fetch('https://example.com/movies.json')
   .then(response => response.json())
   // jsonify the response stream object
-  .then(myJson => console.log(myJson))
+  .then(console.log)
 ```
 
 The other thing Promises are very useful for is when you want to do a bunch of things in tandem.
@@ -287,8 +290,9 @@ The other thing Promises are very useful for is when you want to do a bunch of t
 // and returns a parent promise which will
 // resolve only if all it's children Resolved
 // and reject otherwise.
-Promise.all([promise1, promise2, promise3])
-   .then((values) => console.log("DONE!"))
+Promise
+  .all([promise1, promise2, promise3])
+  .then((_values) => console.log("DONE!"))
 ```
 
 The cool thing about `Promise.all()` is that it lets you run several things at once and keep track of all rather then running them one at a time.
@@ -300,8 +304,9 @@ Of course sometimes you don't want _all_ you just want _one_. A example is if yo
 // will return a promise that resolves or
 // rejects as soon as one of it's children
 // resolves or rejects
-Promise.race([ebay, gumtree, wish])
-   .then((values) => console.log(values))
+Promise
+  .race([ebay, gumtree, wish])
+  .then((values) => console.log(values))
 ```
 
 ## AJAX

--- a/content/async/index.md
+++ b/content/async/index.md
@@ -60,11 +60,11 @@ function callback(data) {
 
 
 let oReq = new XMLHttpRequest();
-oReq.addEventListener("load", callback);
+oReq.addEventListener('load', callback);
 
 // these lines return super quickly even though
 // the server hasn't responded. They don't wait.
-oReq.open("GET","http://www.example.org/example.txt");
+oReq.open('GET', 'http://www.example.org/example.txt');
 oReq.send();
 ```
 
@@ -93,13 +93,13 @@ When you are writing code it's natural to think out your logic top down like thi
 
 ```js
 let name = get_name();
-document.getElementById("name").value = name;
+document.getElementById('name').value = name;
 ```
 but if get_name makes a network call you can't do that, you'd have to do..
 
 ```js
 function callback(name) {
-  document.getElementById("name").value = name;
+  document.getElementById('name').value = name;
 }
 
 // where callback is triggered when get_name returns from its
@@ -111,15 +111,15 @@ get_name(callback);
 
 ```js
 function callback(name) {
-  document.getElementById("name").value = name;
+  document.getElementById('name').value = name;
 }
-document.getElementById("name").value = "lol";
+document.getElementById('name').value = 'lol';
 
 get_name(callback);
 // will print out 'lol' because the callback hasn't  
 // been called yet and we don't know when it will
 // be called.
-console.log(document.getElementById("name").value);
+console.log(document.getElementById('name').value);
 ```
 
 So if you want to do several things that are async in order you have to nest callback functions
@@ -156,11 +156,11 @@ Consider the following:
 
 ```js
 function successCallback(result) {
-  console.log("Audio file ready at URL: " + result);
+  console.log(`Audio file ready at URL: ${result}`);
 }
 
 function failureCallback(error) {
-  console.log("Error generating audio file: " + error);
+  console.log(`Error generating audio file: ${error}`);
 }
 
 createAudioFileAsync(audioSettings, successCallback, failureCallback);
@@ -172,8 +172,8 @@ But if instead `createAudioFileAsync` returned a `Promise` object you could do t
 
 ```js
 createAudioFileAsync(audioSettings)
-   .then(successCallback)
-   .catch(failureCallback);
+  .then(successCallback)
+  .catch(failureCallback);
 ```
 
 The `Promise` object will be notified when the audio file is done and it can then refer to the success and failure functions the user specified.
@@ -188,14 +188,14 @@ Thus they can be chained so we can have various steps of a procedure happen in s
 
 ```js
 doSomething()
-   .then(result => doSomethingElse(result))
-   /*
-      The above can be written as .then(doSomethingElse)
-      This is because .then takes a callback that is passed the
-      return value of the previous promise
-   */
-   .then(newResult => doThirdThing(newResult))
-   .then(finalResult => console.log('Got the final result!'));
+  .then(result => doSomethingElse(result))
+  /*
+    The above can be written as .then(doSomethingElse)
+    This is because .then takes a callback that is passed the
+    return value of the previous promise
+  */
+  .then(newResult => doThirdThing(newResult))
+  .then(finalResult => console.log('Got the final result!'));
 
 ```
 
@@ -239,7 +239,7 @@ myPromise
   .then(() => console.log('Do this, no matter what happened before'))
   // this could also be written as finally
   // ie
-  .finally(() => console.log("Always do this."))
+  .finally(() => console.log("Always do this."));
 ```
 
 #### Creating Promises
@@ -256,7 +256,7 @@ const myFirstPromise = new Promise((resolve, reject) => {
   //   resolve(someValue); // fulfilled
   // or
   //   reject("failure reason"); // rejected
-})
+});
 ```
 
 An alternate way to wrap a non-asynchronous thing in a promise is to use
@@ -268,7 +268,7 @@ eg.
 const data = 10
 Promise
   .resolve(data)
-  .then(data => doSomethingElse(data))
+  .then(data => doSomethingElse(data));
   //TODO: should we do `.then(doSomethingElse)` instead?
 ```
 
@@ -280,7 +280,7 @@ So one of the things JavaScript introduced recently is the `fetch` function whic
 fetch('https://example.com/movies.json')
   .then(response => response.json())
   // jsonify the response stream object
-  .then(console.log)
+  .then(console.log);
 ```
 
 The other thing Promises are very useful for is when you want to do a bunch of things in tandem.
@@ -292,7 +292,7 @@ The other thing Promises are very useful for is when you want to do a bunch of t
 // and reject otherwise.
 Promise
   .all([promise1, promise2, promise3])
-  .then((_values) => console.log("DONE!"))
+  .then((_values) => console.log('DONE!'));
 ```
 
 The cool thing about `Promise.all()` is that it lets you run several things at once and keep track of all rather then running them one at a time.
@@ -306,7 +306,7 @@ Of course sometimes you don't want _all_ you just want _one_. A example is if yo
 // resolves or rejects
 Promise
   .race([ebay, gumtree, wish])
-  .then((values) => console.log(values))
+  .then((values) => console.log(values));
 ```
 
 ## AJAX

--- a/content/basics/functions.md
+++ b/content/basics/functions.md
@@ -12,10 +12,10 @@ each with subtly different behaviour.
 function normalFunction() { }
 
 // anonymous function
-const normalFunction = function() {}
+const normalFunction = function() {};
 
 // anonymous function in line.
-array.map(function(item) { return item + 1 })
+array.map(function(item) { return item + 1 });
 
 // for all of these types of functions, the value of 'this'
 // is bound to the enclosing object.
@@ -28,18 +28,18 @@ However... (as of ES6)
 // The arrow is shorthand for return.
 // it's good practice to include parenthesis around args,
 // but for single arguments, you don't need to.
-const returns10 = () => 10
-const greet = name => "Hello " + name
+const returns10 = () => 10;
+const greet = name => `Hello ${name}`;
 
 // for the example above we get the much nicer
-array.map(item => item + 1)
+array.map(item => item + 1);
 
 // But arrow functions also have one special property!
 // they bind not to the enclosing object, but the surrounding context.
 // This is important in areas where you may normally have had to 'bind' a fn.
-element.addEventListener('click', handler.fn.bind(handler))
+element.addEventListener('click', handler.fn.bind(handler));
 // vs. (FIXME This example could probs be better)
-element.addEventListener('click', () => handler.fn()) // yay!
+element.addEventListener('click', () => handler.fn()); // yay!
 ```
 
 In some cases you may need to explicitly alter the value of `this`
@@ -53,7 +53,7 @@ returns this new function. Common use with event handlers as above.
 ```js
 // now objects methods will be bound to object (as it should be)
 // rather than element (which is the enclosing object)
-element.addEventListener('click', object.method.bind(object))
+element.addEventListener('click', object.method.bind(object));
 ```
 
 ### Call `.call(thisArg, ...args)`
@@ -61,7 +61,7 @@ Call is very similar to `.bind`, except that rather than returning a function,
 it also makes the function call.
 
 ```js
-const returnVal = object.method.call(object, arg1, arg2...)
+const returnVal = object.method.call(object, arg1, arg2...);
 ```
 
 ### Apply `.apply()`
@@ -69,7 +69,7 @@ Apply does exactly the same thing as `.call`, except that it takes an Array,
 rather than an arguments list. IE.
 
 ```js
-const returnVal = object.method.apply(object, [ arg1, arg2 ])
+const returnVal = object.method.apply(object, [arg1, arg2]);
 ```
 
 ## Thinking Functional

--- a/content/basics/index.md
+++ b/content/basics/index.md
@@ -79,7 +79,7 @@ There are a number of ways to declare scripts in the browser. More on that [here
    <body>
       <!-- This is an in-line script -->
       <script>
-         alert('Hello World!')
+         alert('Hello World!');
       </script>
 
       <!-- This also would work, for the local file filename.js -->
@@ -122,9 +122,9 @@ but is also 'hoisted' to the top of the current code block.
 Given this is a common source of bugs, and given it offers no real advantage over `let`, you should really always use `let`.
 
 ```js
-const myVar      = 10
-let   myOtherVar = "Dog"
-var   myVarVar   = [] // should be let or const
+const myVar      = 10;
+let   myOtherVar = 'Dog';
+var   myVarVar   = []; // should be let or const
 ```
 
 ### Operators
@@ -134,8 +134,8 @@ with a few additional ones.
 
 ```js
 // assignment
-let      a = 5
-const list = [1, 5]
+let      a = 5;
+const list = [1, 5];
 
 // bitwise operations
 ^ | & >> <<
@@ -197,10 +197,10 @@ The basic Object declaration is simply:
 // note const limitations apply only to reassigning
 // the Object. Object properties can still be altered
 // with a const declaration.
-const myObject = {}
+const myObject = {};
 
 // or like this
-const myOtherObject = new Object()
+const myOtherObject = new Object();
 ```
 
 The new keyword is a constructor. Similar to Java, `new`
@@ -212,18 +212,18 @@ everything is an object, these differences are more semantic than real.
 Adding a property or methods is as simple as:
 
 ```js
-const myObject = {}
-myObject.a = "a"
+const myObject = {};
+myObject.a = 'a';
 
-myObject.f = function() { return this.a }
+myObject.f = function() { return this.a };
 
 // or in one go:
 const myObject = {
-   a: "a",
+   a: 'a',
    f() {
-      return this.a
+      return this.a;
    }
-}
+};
 ```
 
 A further note, properties and methods can be accessed with the `.` syntax or
@@ -231,7 +231,7 @@ via their string equivalent.
 
 ```js
 // that is
-obj.a == obj['a']
+obj.a == obj['a'];
 ```
 
 #### The dreaded `this`
@@ -265,21 +265,21 @@ This looks something like:
 // note the use of this in this special constructor
 // also note the caps (a convention for constructor functions)
 function Person(firstName, lastName, age) {
-   this.firstName = firstName
-   this.lastName  = lastName
-   this.age       = age
+   this.firstName = firstName;
+   this.lastName  = lastName;
+   this.age       = age;
 }
 
 Person.prototype.getFullName = function() {
-   return this.firstName + " " + this.lastName
-}
+   return `${this.firstName} ${this.lastName}`;
+};
 
 Person.prototype.canDrinkAlcohol = function() {
-   return this.age >= 18
-}
+   return this.age >= 18;
+};
 
 // now if we call the constructor function we get this
-new Person("Jeff", "Goldblum", 50)
+new Person('Jeff', 'Goldblum', 50);
 // => Person { firstName: 'Jeff', lastName: 'Goldblum', age: 50 }
 ```
 
@@ -305,17 +305,17 @@ function PersonFactory(firstName, lastName, age) {
 
    return {
       getFullName () {
-         return firstName + " " + lastName
+         return `${firstName} ${lastName}`;
       },
 
       canDrinkAlcohol() {
-         return age >= 18
+         return age >= 18;
       }
    }
 }
 
 // which we'd call like
-const jeff = PersonFactory("Jeff", "Goldblum", 50)
+const jeff = PersonFactory('Jeff', 'Goldblum', 50);
 ```
 
 ## Scope, Control Flow, Loops and Iteration
@@ -337,15 +337,15 @@ Essentially:
 
 ```js
 // function is called 'before' it's declared (valid)
-myFunction() // will output Hi Andrew
+myFunction(); // will output Hi Andrew
 
 function myFunction() {
    // name refers to the var name via hoisting
-   name = "Andrew"
-   console.log("Hi", name)
+   name = 'Andrew';
+   console.log('Hi', name);
 }
 // this will be hoisted
-var name
+var name;
 ```
 ... Is valid.
 
@@ -363,22 +363,22 @@ function closureFunction() {
    // here the count variable is only in the function's scope,
    // but myObject stores a reference so it hangs around even when
    // the function returns.
-   let count = 0
+   let count = 0;
 
    const myObject = {
       counter() {
-         return count
+         return count;
       },
       increment() {
-         count++
+         count++;
       }
-   }
+   };
 
-   return myObject
+   return myObject;
 }
 
-const obj = closureFunction()
-obj.counter() // == 0 Because obj has a reference to count
+const obj = closureFunction();
+obj.counter(); // == 0 Because obj has a reference to count
 ```
 
 #### Garbage Collection
@@ -408,35 +408,35 @@ else
    // something else
 
 // And of course ternary
-const x = condition ? 22 : 0
+const x = condition ? 22 : 0;
 ```
 
 
 ### Loops
 Let's assume we have an Object and Array as below:
 ```js
-const array = [ "Teddy", "Clock"]
+const array = ['Teddy', 'Clock'];
 
 const item = {
-   name: "Box",
+   name: 'Box',
    weight: 10,
    contents: array
-}
+};
 ```
 
 The `while` or `do-while` loop:
 ```js
 // same as c
-let index = 0
+let index = 0;
 
 while (index < array.length) {
-   let value = array[index]
-   index++
+   let value = array[index];
+   index++;
 }
 
 do {
-   let value = array[index]
-   index++
+   let value = array[index];
+   index++;
 } while (index < array.length);
 
 ```
@@ -447,7 +447,7 @@ The `c-style` loop:
 for (let index = 0; index < array.length; index++) {
    // do something with item
    // very similar to c
-   let value = array[index]
+   let value = array[index];
 }
 ```
 
@@ -457,7 +457,7 @@ The `for ... in` loop:
 for (const property in items) {
    // do something with item
    // very similar to python
-   let value = items[property]
+   let value = items[property];
 }
 ```
 
@@ -467,7 +467,7 @@ The `for ... of` loop:
 // Common iterables include String and Array types.
 for (const item of array) {
    // the value of item for each iteration
-   item => ["Teddy", "Clock"]
+   item => ['Teddy', 'Clock'];
 }
 ```
 
@@ -478,21 +478,21 @@ and if it fails catch the exceptions thrown by the thing that went wrong.
 
 ```js
 try {
-   somethingBad()
+   somethingBad();
 } catch (e) {
    // an error occurred
-   const message = e.message
+   const message = e.message;
 } finally {
    // do something that u would do either way
 }
 
 // can create own errors or throw errors like so.
-const e = new Error("Bad Thing Happened")
+const e = new Error('Bad Thing Happened');
 
 // And there's also the 'throw' syntax
 // you don't even need to create a custom error you can simply throw signal
 // something went wrong.
-throw "Error"
+throw 'Error';
 ```
 
 One further note on errors. We can, if we so choose, create specific catch handlers.
@@ -501,7 +501,7 @@ Most of the time this is overkill, but it can be useful:
 
 ```js
 try {
-    somethingBad()
+    somethingBad();
 } catch (e if e instanceof TypeError) {
     // statements to handle TypeError exceptions
 } catch (e if e instanceof RangeError) {

--- a/content/basics/objects.md
+++ b/content/basics/objects.md
@@ -23,16 +23,16 @@ callback function passed in. Callback should return true or false.
 
 ```js
 
-const array = [1, 2, 3, 4]
+const array = [1, 2, 3, 4];
 
 function odd(num) {
-   return num % 2
+   return num % 2;
 }
 
-const odd_only = array.filter(odd) // [ 1, 3 ]
+const odd_only = array.filter(odd); // [ 1, 3 ]
 
 // or with arrow func
-const odd_only = array.filter(curr => curr % 2) // [ 1, 3 ]
+const odd_only = array.filter(curr => curr % 2); // [ 1, 3 ]
 ```
 
 ### Map `.map(fn)`
@@ -41,25 +41,25 @@ The function passed in should return the mapped value
 
 ```js
 
-const array = [1, 2, 3, 4]
+const array = [1, 2, 3, 4];
 
 function double(num) {
-   return num % 2
+   return num % 2;
 }
 
-const double = array.map(double) // [ 2, 4, 6, 8 ]
+const double = array.map(double); // [ 2, 4, 6, 8 ]
 
 // or with arrow func
-const double = array.map(curr => curr * 2) // [ 2, 4, 6, 8 ]
+const double = array.map(curr => curr * 2); // [ 2, 4, 6, 8 ]
 ```
 
 ### Reduce `.reduce(fn)`
 Look up docs. Very versatile.
 
 ```js
-const array = [1, 2, 3, 4]
+const array = [1, 2, 3, 4];
 
-const sum = array.reduce((sum, current) => sum + current, 0) // 1+2+3+4
+const sum = array.reduce((sum, current) => sum + current, 0); // 1+2+3+4
 ```
 
 ### Join `.join(delimiter)`
@@ -78,8 +78,8 @@ you to quickly and easily select elements in an array. eg.
 
 ```js
 // spread
-const list = [10, 12, 13]
-const [..., a, b] = list
+const list = [10, 12, 13];
+const [ ..., a, b ] = list;
 // a == 12, b == 13
 
 // alternatively in a function.

--- a/content/basics/objects.md
+++ b/content/basics/objects.md
@@ -26,7 +26,7 @@ callback function passed in. Callback should return true or false.
 const array = [1, 2, 3, 4];
 
 function odd(num) {
-   return num % 2;
+  return num % 2;
 }
 
 const odd_only = array.filter(odd); // [ 1, 3 ]
@@ -44,7 +44,7 @@ The function passed in should return the mapped value
 const array = [1, 2, 3, 4];
 
 function double(num) {
-   return num % 2;
+  return num % 2;
 }
 
 const double = array.map(double); // [ 2, 4, 6, 8 ]
@@ -85,7 +85,7 @@ const [ ..., a, b ] = list;
 // alternatively in a function.
 function spread(a, b, c) {}
 spread(...list) {
-   // a, b, c now set appropately
+  // a, b, c now set appropately
 }
 ```
 

--- a/content/devtools.md
+++ b/content/devtools.md
@@ -17,7 +17,7 @@ browser devtools. It'll look something like this on `Chrome`.
 For the most basic type of debugging, you can use:
 
 ```js
-console.log("some debug string...")
+console.log('some debug string...');
 ```
 
 .. In your JavaScript code

--- a/content/dom/index.md
+++ b/content/dom/index.md
@@ -47,43 +47,43 @@ following methods.
 ```js
 // document is global, returns an html element
 // with the specific id.
-document.getElementById(id)
+document.getElementById(id);
 
 // returns a DOM HTMLCollection
-document.getElementsByTagName(name)
+document.getElementsByTagName(name);
 
 // returns an html element
-document.createElement(name)
+document.createElement(name);
 
 // returns a list
-document.getElementsByClassName(className)
+document.getElementsByClassName(className);
 
 // node and element interactions
-parentNode.appendChild(node)
-parentNode.removeChild(node)
+parentNode.appendChild(node);
+parentNode.removeChild(node);
 
 // access what's in a node
 node.nodeData or node.data
 
 // access what's in an element
-element.innerHTML
-element.textContent // not always what u want, read docs.
+element.innerHTML;
+element.textContent; // not always what u want, read docs.
 
 // change the style.
-element.style.left
+element.style.left;
 
 // as advertised
-element.setAttribute(attr, value)
-element.getAttribute(attr)
-element.addEventListener(eventType, handler)
+element.setAttribute(attr, value);
+element.getAttribute(attr);
+element.addEventListener(eventType, handler);
 
 // window is also global (in fact the window encloses the document)
-window.onload = () => init()
-window.dump()
-window.scrollTo()
-window.innerHeight
-window.innerWidth
-window.addEventListener(eventType, handler)
+window.onload = init;
+window.dump();
+window.scrollTo();
+window.innerHeight;
+window.innerWidth;
+window.addEventListener(eventType, handler);
 ```
 
 ## Events and the Event Loop
@@ -101,7 +101,7 @@ The Event Loop is at its core quite simple, in JavaScript is something like the 
 
 ```js
 while (queue.waitForMessage()) {
-  queue.processNextMessage()
+  queue.processNextMessage();
 }
 ```
 
@@ -147,7 +147,7 @@ with the specific node that was interacted with; and its children.
 ```html
 <script>
   function myFunction(){
-    alert('i am a hack0r')
+    alert('i am a hack0r');
   }
 </script>
 
@@ -160,11 +160,11 @@ A better way to attach event handlers is in JavaScript code. In practice this is
 ```js
 // generally preferred style
 document
-   .getElementById("mybutton")
-   .addEventListener('click', function(event) {})
+  .getElementById("mybutton")
+  .addEventListener('click', function(event) {});
 
 // this also works
-document.getElementById("mybutton").onclick = function(event) {}
+document.getElementById("mybutton").onclick = function(event) {};
 ```
 
 Here what we have done is _bound_ an inline listener function to a DOM Node and an event -- the
@@ -179,11 +179,11 @@ function myEventHandler(event) { ... }
 
 // generally preferred style
 document
-   .getElementById("mybutton")
-   .addEventListener('click', myEventHandler)
+  .getElementById("mybutton")
+  .addEventListener('click', myEventHandler);
 
 // but this works too
-document.getElementById("mybutton").onclick = myEventHandler
+document.getElementById("mybutton").onclick = myEventHandler;
 ```
 
 The event object is hard to say anything about because what it contains depends on the event. A KeyPress event object holds information on what key was pressed, a click holds information on where the click happened etc. See the [MDN docs](https://developer.mozilla.org/en-US/docs/Web/Events) for more info.
@@ -195,17 +195,17 @@ There are also some events that don't directly relate to a specific DOM node, su
 These are declared in the same way but we bind our event handlers to the `window` which acts as an overarching anchor for our events.
 
 ```js
-window.addEventListener("load",
-   (event) => console.log("All resources finished loading!"))
-window.addEventListener("resize",
-   (event) => console.log("Screen was resized"))
+window.addEventListener('load',
+   (_event) => console.log('All resources finished loading!'));
+window.addEventListener('resize',
+   (_event) => console.log('Screen was resized'));
 ```
 
 A very common event used is a timeout event where a certain function is run after a certain amount of time
 
 ```js
 // print out hello after 3000ms (3 seconds)
-setTimeout(() => alert("Hello"), 3000)
+setTimeout(() => alert('Hello'), 3000);
 ```
 
 JavaScript also lets you make your own custom events and state when you want them to fire but for now that's out of the scope.
@@ -219,19 +219,19 @@ but to recap, `this` refers to the _enclosing_ object.
 When the function is in a object, this refers to the object itself. This is similar to how python implements `self` and java implements `this`. But context matters!
 
 ```js
-console.log(this) // window
+console.log(this); // window
 function f(){
-  console.log(this) // still window
+  console.log(this); // still window
 }
 
 const person = {
-    firstName: "John",
-    lastName : "Doe",
+    firstName: 'John',
+    lastName : 'Doe',
     id       : 5566,
     fullName : function() {
-        return this.firstName + " " + this.lastName
+        return `${this.firstName} ${this.lastName}`;
     }
-}
+};
 ```
 
 This is all dandy but what's cool is that when a event is triggered, `this` is bound to the node on which the listener is attached.
@@ -306,7 +306,7 @@ Or we can be very specific in how we react to an event, `event.target` holds the
 function myHandler(event) {
   // i don't care about nested events
   if (event.target != this) {
-    return
+    return;
   }
 
   /* this is a demo, there are better ways to do this */

--- a/content/node.md
+++ b/content/node.md
@@ -19,9 +19,9 @@ Eg. Let's say we're prepping a basic script for the browser and we want to test 
 ```js
 // a script without DOM interactions
 // list.js
-const list = ["Sam", "Delilah", "Mary"]
+const list = ['Sam', 'Delilah', 'Mary'];
 
-console.log(list.indexOf("Mary"))
+console.log(list.indexOf('Mary'));
 ```
 
 ```bash

--- a/examples/async/blocked/blocked.js
+++ b/examples/async/blocked/blocked.js
@@ -2,31 +2,31 @@
 // By wrapping our code in a function we
 // don't pollute global scope.
 function init() {
-   // register a event handler
-   // to print the key pressed whenever
-   // a key is pressed
-   window.addEventListener('keypress', (event) => {
-      event.preventDefault()
-      const keyName    = event.key
-      const output     = document.getElementById("output")
-      if (keyName.length == 1)
-        output.appendChild(document.createTextNode(keyName))
-   })
+  // register a event handler
+  // to print the key pressed whenever
+  // a key is pressed
+  window.addEventListener('keypress', (event) => {
+    event.preventDefault();
+    const keyName    = event.key;
+    const output     = document.getElementById('output');
+    if (keyName.length == 1)
+      output.appendChild(document.createTextNode(keyName));
+  });
 
-   const button = document
-                     .getElementById('button')
-                     .addEventListener('click', slow)
+  const button = document
+                   .getElementById('button')
+                   .addEventListener('click', slow);
 
-   //super slow function
-   function slow(){
-     let i = 0
-     while(i < 2000000000) i++
-     alert("Done doing slow stuff!")
-   }
+  //super slow function
+  function slow(){
+    let i = 0;
+    while(i < 2000000000) i++;
+    alert("Done doing slow stuff!");
+  }
 
-   // just remove defunct listener
-   document.removeEventListener('DOMContentLoaded', init)
+  // just remove defunct listener
+  document.removeEventListener('DOMContentLoaded', init);
 }
 
 // add event listener
-document.addEventListener('DOMContentLoaded', init)
+document.addEventListener('DOMContentLoaded', init);

--- a/examples/async/fetch/fetch.js
+++ b/examples/async/fetch/fetch.js
@@ -1,31 +1,31 @@
 function init() {
 
-   function getUsers(){
-     // let the user know we are loading
-     Library.print("loading...")
+  function getUsers(){
+    // let the user know we are loading
+    Library.print('loading...');
 
-     /* AJAX example */
-     const API_URL = "https://jsonplaceholder.typicode.com/"
+    /* AJAX example */
+    const API_URL = 'https://jsonplaceholder.typicode.com/';
 
-     /* Assuming a browser context */
-     Library.getJSON(API_URL + 'users')
-        // chain the promise and translate the response
-        // object in json to a js object
-        .then(data => {
-           // remove loading message
-           Library.clearOutput()
-           return data
-        })
-        .then(data => data.map(user => Library.print(user.name)))
-   }
+    /* Assuming a browser context */
+    Library.getJSON(`${API_URL}users`);
+    // chain the promise and translate the response
+    // object in json to a js object
+    .then((data) => {
+      // remove loading message
+      Library.clearOutput();
+      return data;
+    })
+    .then(data => data.map(user => Library.print(user.name)));
+  }
 
-   document
-      .getElementById('button')
-      .addEventListener('click', getUsers)
+  document
+    .getElementById('button')
+    .addEventListener('click', getUsers);
 
-   // just remove defunct listener
-   document.removeEventListener('DOMContentLoaded', init)
+  // just remove defunct listener
+  document.removeEventListener('DOMContentLoaded', init);
 }
 
 // add event listener
-document.addEventListener('DOMContentLoaded', init)
+document.addEventListener('DOMContentLoaded', init);

--- a/examples/async/promises/promises.js
+++ b/examples/async/promises/promises.js
@@ -12,76 +12,79 @@ but is not the way js would run without promises.
 
 function init() {
 
-   const time = {}
-   const API_URL = "https://jsonplaceholder.typicode.com"
-   const requestURIs =
-      [1,2,3].map(num => `${API_URL}/users/${num}`)
+  const time = {};
+  const API_URL = 'https://jsonplaceholder.typicode.com';
+  const requestURIs =
+    [1,2,3].map(num => `${API_URL}/users/${num}`);
 
-   function finishRequestTiming() {
-      // mark the end of the request.
-      time.end = Date.now()
-      const delta = time.end - time.start
-      Library.printLight(delta+" ms")
-   }
+  function finishRequestTiming() {
+    // mark the end of the request.
+    time.end = Date.now();
+    const delta = time.end - time.start;
+    Library.printLight(`${delta} ms`);
+  }
 
-   function togetherGet() {
-     Library.clearOutput()
-     Library.print("loading...")
-     time.start = Date.now()
-     // form a list of Promises
-     // where we are getting serveral users
-     const listOfPromises = requestURIs.map(Library.getJSON)
-     // run them all at the same time
-     // and once all are done, display them
-     Promise.all(listOfPromises)
-       .then(users => users.map(user => Library.print(user.name)))
-       .then(finishRequestTiming)
-   }
+  function togetherGet() {
+    Library.clearOutput();
+    Library.print('loading...');
+    time.start = Date.now();
+    // form a list of Promises
+    // where we are getting serveral users
+    const listOfPromises = requestURIs.map(Library.getJSON);
+    // run them all at the same time
+    // and once all are done, display them
+    Promise
+      .all(listOfPromises)
+      .then(users => users.map(user => Library.print(user.name)))
+      .then(finishRequestTiming);
+  }
 
-   function synchronousGet(){
-     Library.clearOutput()
-     Library.print("loading...")
-     time.start = Date.now()
+  function synchronousGet(){
+    Library.clearOutput();
+    Library.print('loading...');
+    time.start = Date.now();
 
-     // this is going to take longer as we're
-     // going to process one request at a time.
-     requestURIs.reduce((requests, uri) =>
-         requests
-         .then(() => Library.getJSON(uri))
-         .then(user => Library.print(user.name))
-     , Promise.resolve(null))
-     .then(finishRequestTiming)
-   }
+    // this is going to take longer as we're
+    // going to process one request at a time.
+    requestURIs
+      .reduce((requests, uri) => {
+        return requests
+          .then(() => Library.getJSON(uri))
+          .then(user => Library.print(user.name));
+        }, Promise.resolve(null))
+      .then(finishRequestTiming);
+  }
 
-   // Promise constructor
-   const delay = (ms) => new Promise((resolve, reject) => {
+  // Promise constructor
+  const delay = (ms) => {
+    return new Promise((resolve, reject) => {
       // this will simply delay execution for ms milliseconds
       // in a controlled way
       try {
-         setTimeout(resolve, ms)
+        setTimeout(resolve, ms);
       } catch (e) {
-         reject(e)
+        reject(e);
       }
-   })
+    });
+  };
 
-   function waitAndLove() {
-     // wait 1 second (so you don't seem desperate)
-     // then say i love you
-     delay(1000)
-      .then(() => alert("I love you <3"))
-   }
+  function waitAndLove() {
+    // wait 1 second (so you don't seem desperate)
+    // then say i love you
+    delay(1000).then(() => alert('I love you <3'));
+  }
 
-   [
-      { id: 'wait', listener: waitAndLove },
-      { id: 'all', listener: togetherGet },
-      { id: 'notAll', listener: synchronousGet }
-   ].forEach(({ id, listener }) => {
-      document
-         .getElementById(id)
-         .addEventListener('click', listener)
-   })
+  [
+    {id: 'wait', listener: waitAndLove},
+    {id: 'all', listener: togetherGet},
+    {id: 'notAll', listener: synchronousGet}
+  ].forEach(({ id, listener }) => {
+    document
+      .getElementById(id)
+      .addEventListener('click', listener);
+  });
 
-   document.removeEventListener('DOMContentLoaded', init)
+  document.removeEventListener('DOMContentLoaded', init);
 }
 
-document.addEventListener('DOMContentLoaded', init)
+document.addEventListener('DOMContentLoaded', init);

--- a/examples/async/timeouts/timeout.js
+++ b/examples/async/timeouts/timeout.js
@@ -5,19 +5,17 @@ function init() {
   // Remember that once a event is on the event queue it isn't run
   // untill the current block of code that's being run is finished
   function main() {
-     Library.print('Hello');
-     setTimeout(() => {
-        Library.print("World")
-     }, 0)
-     Library.print("End")
-   }
-   // bind
-   document
-      .getElementById('button')
-      .addEventListener('click', main)
-   // just remove defunct listener
-   document.removeEventListener('DOMContentLoaded', init)
+    Library.print('Hello');
+    setTimeout(() => Library.print('World'), 0);
+    Library.print('End');
+  }
+  // bind
+  document
+    .getElementById('button')
+    .addEventListener('click', main);
+  // just remove defunct listener
+  document.removeEventListener('DOMContentLoaded', init);
 }
 
 // add event listener
-document.addEventListener('DOMContentLoaded', init)
+document.addEventListener('DOMContentLoaded', init);

--- a/examples/async/timeouts/timeout.js
+++ b/examples/async/timeouts/timeout.js
@@ -5,7 +5,7 @@ function init() {
   // Remember that once a event is on the event queue it isn't run
   // untill the current block of code that's being run is finished
   function main() {
-     Library.print("Hello")
+     Library.print('Hello');
      setTimeout(() => {
         Library.print("World")
      }, 0)

--- a/examples/basic/arrays.js
+++ b/examples/basic/arrays.js
@@ -5,43 +5,42 @@
 
    key among thse are map, filter and reduce
 */
-const properNoun = (noun) =>
-   noun.charAt(0).toUpperCase() + noun.substring(1)
+const properNoun = noun => noun.charAt(0).toUpperCase() + noun.substring(1);
 
 // let's note the power with cleaning some user data.
 const users = [
-   {
-      name: "Jeff",
-      age: 52,
-      gender: "male"
-   },
-   {
-      name: "Andy",
-      age: 25,
-      gender: "male"
-   },
-   {
-      name: "Sarah",
-      age: 30,
-      gender: "female"
-   },
-   {
-      name: "Phoebe",
-      age: 21,
-      gender: "female"
-   },
-   {
-      name: "Doris",
-      age: 81,
-      gender: "female"
-   }
-]
+  {
+    name: 'Jeff',
+    age: 52,
+    gender: 'male'
+  },
+  {
+    name: 'Andy',
+    age: 25,
+    gender: 'male'
+  },
+  {
+    name: 'Sarah',
+    age: 30,
+    gender: 'female'
+  },
+  {
+    name: 'Phoebe',
+    age: 21,
+    gender: 'female'
+  },
+  {
+    name: 'Doris',
+    age: 81,
+    gender: 'female'
+  }
+];
 
 // let's get the average age of females.
-const females = users.filter(user => user.gender == "female")
-const ageSum = (sum, current) => current.age + sum
-const average = females.reduce(ageSum, 0)/females.length
-console.log(average)
+const females = users.filter(user => user.gender === 'female');
+const ageSum = (sum, current) => current.age + sum;
+const average = females.reduce(ageSum, 0) / females.length;
+console.log(average);
 
 // let's capitalise the gender category
 // note object destructuring
@@ -49,12 +48,12 @@ const betterUsers = users.map(({ name, age, gender }) => ({
    name,
    age,
    gender: properNoun(gender)
-}))
+}));
 
 // or creating a summary string with map + reduce.
 const usersString = users
-   .map(({ name, age, gender }) =>
-      `${name} (${gender}) is ${age} years of age.`)
-   .reduce((all, curr) => all+"\n"+curr)
+                      .map(({ name, age, gender }) =>
+                         `${name} (${gender}) is ${age} years of age.`)
+                      .reduce((all, curr) => `${all}\n${curr}`);
 
-console.log(usersString)
+console.log(usersString);

--- a/examples/basic/binding.js
+++ b/examples/basic/binding.js
@@ -2,24 +2,22 @@
 const o = {
    bb: 0,
    f() {
-      return this.bb
+      return this.bb;
    }
-}
+};
 
-o.f() // 0
+o.f(); // 0
 
 // 'unbind'// detach function
-let a = o.f // a == f() { return this.b }
+let a = o.f; // a == f() { return this.b }
 
-const oo = {
-   bb: "Barry"
-}
+const oo = {bb: 'Barry'};
 
 // .call means we call the function and use this as 'oo'
-a.call(oo) //  "Barry"
+a.call(oo); //  'Barry'
 
 // Essentially wire a to oo
 // f is now a function bound to the object oo.
-const f = a.bind(oo)
+const f = a.bind(oo);
 
-f() // "Barry" .. further calls will always reference 'oo' as this
+f(); // 'Barry' .. further calls will always reference 'oo' as this

--- a/examples/basic/class.js
+++ b/examples/basic/class.js
@@ -5,20 +5,20 @@
 
 class Person {
    constructor(firstName, lastName, age) {
-      this.firstName = firstName
-      this.lastName  = lastName
-      this.age       = age
+      this.firstName = firstName;
+      this.lastName  = lastName;
+      this.age       = age;
    }
 
    getFullName() {
-      return this.firstName + " " + this.lastName
+      return `${this.firstName} ${this.lastName}`;
    }
 
    canDrinkAlcohol() {
-      return this.age >= 18
+      return this.age >= 18;
    }
 }
 
 // now if we call the constructor function we get this
-const jeff = new Person("Jeff", "Goldblum", 50)
+const jeff = new Person('Jeff', 'Goldblum', 50);
 // => Person { firstName: 'Jeff', lastName: 'Goldblum', age: 50 }

--- a/examples/basic/closure.js
+++ b/examples/basic/closure.js
@@ -4,19 +4,19 @@ function closureFunction() {
    // here the count variable is only in the function's scope,
    // but myObject stores a reference so it hangs around even when
    // the function returns.
-   let count = 0
+   let count = 0;
 
    const myObject = {
       counter() {
-         return count
+         return count;
       },
       increment() {
-         count++
+         count++;
       }
-   }
+   };
 
-   return myObject
+   return myObject;
 }
 
-const obj = closureFunction()
-obj.counter() // == 0 Because obj has a reference to count
+const obj = closureFunction();
+obj.counter(); // == 0 Because obj has a reference to count

--- a/examples/basic/objects.js
+++ b/examples/basic/objects.js
@@ -3,19 +3,19 @@
 // In fact until recently the concept of a map in JS
 // didn't exist -- it was just an object.
 
-const cart = ["Apple", "Orange", "Apple", "Strawberry", "Orange"]
+const cart = ['Apple', 'Orange', 'Apple', 'Strawberry', 'Orange'];
 // let's translate our cart into a key-value pair object
 // which holds the count of each object.
 
-const count = {}
+const count = {};
 
 for (const item of cart) {
    // check if the key exists, if it doesn't
    // it's undefined.
-   count[item] = count[item] ? count[item] + 1 : 1
+   count[item] = count[item] ? count[item] + 1 : 1;
 }
 
-console.log(count)
+console.log(count);
 // { Apple: 2, Orange: 2, Strawberry: 1 }
 
 /*
@@ -27,20 +27,20 @@ console.log(count)
    [object Object]..
 */
 
-const shopping_cart = {}
+const shopping_cart = {};
 
 const shopping = [
-   { item: "Apple", price: 10 },
-   { item: "Orange", price: 12 },
-   { item: "Apple", price: 10 }
-]
+   {item: 'Apple', price: 10},
+   {item: 'Orange', price: 12},
+   {item: 'Apple', price: 10}
+];
 
 for (const item of shopping) {
    // As above.
-   shopping_cart[item] = shopping_cart[item] ? shopping_cart[item] + 1 : 1
+   shopping_cart[item] = shopping_cart[item] ? shopping_cart[item] + 1 : 1;
 }
 
-console.log(shopping_cart)
+console.log(shopping_cart);
 // { '[object Object]': 3 }
 
 // For these use Map or Set instead, depending n what's required.

--- a/examples/basic/prototype.js
+++ b/examples/basic/prototype.js
@@ -1,19 +1,19 @@
 // note the use of this in this special constructor
 // also note the caps (a convention for constructor functions)
 function Person(firstName, lastName, age) {
-   this.firstName = firstName
-   this.lastName  = lastName
-   this.age       = age
+   this.firstName = firstName;
+   this.lastName  = lastName;
+   this.age       = age;
 }
 
-Person.prototype.getFullName = function() {
-   return this.firstName + " " + this.lastName
-}
+Person.prototype.getFullName = function () {
+   return `${this.firstName} ${this.lastName}`;
+};
 
-Person.prototype.canDrinkAlcohol = function() {
-   return this.age >= 18
-}
+Person.prototype.canDrinkAlcohol = function () {
+   return this.age >= 18;
+};
 
 // now if we call the constructor function we get this
-const jeff = new Person("Jeff", "Goldblum", 50)
+const jeff = new Person('Jeff', 'Goldblum', 50);
 // => Person { firstName: 'Jeff', lastName: 'Goldblum', age: 50 }

--- a/examples/basic/strings.js
+++ b/examples/basic/strings.js
@@ -1,20 +1,20 @@
 
 /* String operations */
-let firstName  = "alex"
-let secondName = "afzal"
+let firstName  = 'alex';
+let secondName = 'afzal';
 
 /* Strings can be concatenated with the + operator */
-const fullName = firstName + " " + secondName
+const fullName = firstName + ' ' + secondName;
 
 // we can also use template literals to format strings as so
-const altFullName = `${firstName} ${secondName}`
+const altFullName = `${firstName} ${secondName}`;
 
 // but maybe we want to capitalise the first letters.
 // turns out to do that it's kinda gross.
 // we can't simply index as we can in other languages
 const properNoun = (noun) =>
-   noun.charAt(0).toUpperCase() + noun.substring(1)
+   noun.charAt(0).toUpperCase() + noun.substring(1);
 
 // so to combine that.
 const properFullName =
-   properNoun(firstName) + " " + properNoun(secondName)
+   `${properNoun(firstName)} ${properNoun(secondName)}`;

--- a/examples/dom/events/events.js
+++ b/examples/dom/events/events.js
@@ -1,17 +1,17 @@
 
 function init() {
 
-   const out = document.getElementById('output')
-   window.addEventListener('click', clicker)
+  const out = document.getElementById('output')
+  window.addEventListener('click', clicker)
 
-   function clicker(event) {
-      out.innerText =
-         `Element Clicked: ${event.target.tagName}\n\
-          Text Content: ${event.target.innerText}`
-   }
+  function clicker(event) {
+    out.innerText =
+    `Element Clicked: ${event.target.tagName}\n\
+      Text Content: ${event.target.innerText}`;
+  }
 
-   document.removeEventListener('DOMContentLoaded', init)
+  document.removeEventListener('DOMContentLoaded', init);
 }
 
 // here's a differnet way to exec js scripts
-document.addEventListener('DOMContentLoaded', init)
+document.addEventListener('DOMContentLoaded', init);

--- a/examples/dom/list/list.js
+++ b/examples/dom/list/list.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict';
 
 // this is one way to avoid populating the global scope
 // and immediately run a script.
 (function() {
-   const names = ["Jeff", "Sally", "Jessica", "Selina", "Bobby"]
-   const parent = document.getElementById('main')
+   const names = ['Jeff', 'Sally', 'Jessica', 'Selina', 'Bobby'];
+   const parent = document.getElementById('main');
 
-   const list = document.createElement('ul')
+   const list = document.createElement('ul');
 
-   let innerHTML = ""
+   let innerHTML = '';
    for (const name of names) {
-      innerHTML += `<li>${name}</li>`
+      innerHTML += `<li>${name}</li>`;
    }
 
-   list.innerHTML = innerHTML
+   list.innerHTML = innerHTML;
 
-   parent.appendChild(list)
-})()
+   parent.appendChild(list);
+})();


### PR DESCRIPTION
- _ for unused arguments
- Single quote is standard for strings
- Array [a, b, c]. Unpacking: [ a, b, c ] = arr;
- Proper use of format string
- For arrow functions there are only two proper ways for a single argument function `x => stuff` or `(x) => { stuff that can't fit in one line }`
- The other thing is the code base originally already had inconsistent style
